### PR TITLE
Fix tests - use json-e tc-github and use py36 / py37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.python-version
 
 # Docs
 _build

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,27 +1,36 @@
-version: 0
-metadata:
-  name: Redo Task Graph
-  description: Redo
-  owner: "{{ event.head.user.email }}"
-  source: "{{ event.head.repo.url }}"
+version: 1
 tasks:
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "{{ taskcluster.docker.workerType }}"
-    payload:
-      maxRunTime: 1200
-      image: "python/3.7"
-      command:
-        - "/bin/bash"
-        - "-c"
-        - "git clone {{ event.head.repo.url }} && cd redo && git checkout {{ event.head.repo.branch }} && pip install tox && tox -e py37"
-    extra:
-      github:
-        env: true
-        events:
-          - push
-          - pull_request.*
-    metadata:
-      name: Redo Pull Request
-      description: Pull Request
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
+  $let:
+    # Github events have this stuff in different places...
+    repo_url: {$if: 'tasks_for == "github-push"',
+               then: '${event.repository.clone_url}'}
+    head_sha: {$if: 'tasks_for == "github-push"',
+               then: '${event.after}'}
+    owner_email: {$if: 'tasks_for == "github-push"',
+                  then: '${event.pusher.email}'}
+  in:
+    $map: [['py37', 'python:3.7'], ['py36', 'python:3.6']]
+    each(py):
+      taskId: "${as_slugid(py[0])}"
+      provisionerId: "aws-provisioner-v1"
+      workerType: "github-worker"
+      created: {$eval: 'now'}
+      deadline: {$fromNow: '1 hour'}
+      payload:
+        maxRunTime: 1200
+        image: {$eval: 'py[1]'}
+        command:
+          - "/bin/bash"
+          - "-c"
+          - "git clone ${repo_url} redo && cd redo && git checkout ${head_sha} && pip install tox && tox -e ${py[0]}"
+      extra:
+        github:
+          env: true
+          events:
+            - push
+            - pull_request.*
+      metadata:
+        name: Redo Pull Request ${py[0]}
+        description: Pull Request ${py[0]}
+        owner: ${owner_email}
+        source: "${repo_url}"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,11 +3,17 @@ tasks:
   $let:
     # Github events have this stuff in different places...
     repo_url: {$if: 'tasks_for == "github-push"',
-               then: '${event.repository.clone_url}'}
+               then: '${event.repository.clone_url}',
+               # Assume Pull Request
+               else: '${event.pull_request.head.repo.clone_url}'}
     head_sha: {$if: 'tasks_for == "github-push"',
-               then: '${event.after}'}
+               then: '${event.after}',
+               # Assume Pull Request
+               else: '${event.pull_request.head.sha}'}
     owner_email: {$if: 'tasks_for == "github-push"',
-                  then: '${event.pusher.email}'}
+                  then: '${event.pusher.email}',
+                  # Assume Pull Request
+                  else: '${event.pull_request.user.login}@users.noreply.github.com'}
   in:
     $map: [['py37', 'python:3.7'], ['py36', 'python:3.6']]
     each(py):

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,7 +15,9 @@ tasks:
                   # Assume Pull Request
                   else: '${event.pull_request.user.login}@users.noreply.github.com'}
   in:
-    $map: [['py37', 'python:3.7'], ['py36', 'python:3.6']]
+    $map: [['py27', 'python:2.7'], ['pypy', 'pypy:2'],
+           ['py34', 'python:3.4'], ['py35', 'python:3.5'],
+           ['py36', 'python:3.6'], ['py37', 'python:3.7']]
     each(py):
       taskId: "${as_slugid(py[0])}"
       provisionerId: "aws-provisioner-v1"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -9,11 +9,11 @@ tasks:
     workerType: "{{ taskcluster.docker.workerType }}"
     payload:
       maxRunTime: 1200
-      image: "bhearsum/python-test-runner"
+      image: "python/3.7"
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone {{ event.head.repo.url }} && cd redo && git checkout {{ event.head.repo.branch }} && tox"
+        - "git clone {{ event.head.repo.url }} && cd redo && git checkout {{ event.head.repo.branch }} && pip install tox && tox -e py37"
     extra:
       github:
         env: true

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,6 @@
 version: 1
+policy:
+  pullRequests: public
 tasks:
   $let:
     # Github events have this stuff in different places...
@@ -15,6 +17,7 @@ tasks:
                   # Assume Pull Request
                   else: '${event.pull_request.user.login}@users.noreply.github.com'}
   in:
+    # map tox command -> docker image
     $map: [['py27', 'python:2.7'], ['pypy', 'pypy:2'],
            ['py34', 'python:3.4'], ['py35', 'python:3.5'],
            ['py36', 'python:3.6'], ['py37', 'python:3.7']]
@@ -31,12 +34,6 @@ tasks:
           - "/bin/bash"
           - "-c"
           - "git clone ${repo_url} redo && cd redo && git checkout ${head_sha} && pip install tox && tox -e ${py[0]}"
-      extra:
-        github:
-          env: true
-          events:
-            - push
-            - pull_request.*
       metadata:
         name: Redo Pull Request ${py[0]}
         description: Pull Request ${py[0]}

--- a/redo/cmd.py
+++ b/redo/cmd.py
@@ -49,5 +49,6 @@ def main():
         rc = getattr(e, "returncode", -2)
         sys.exit(rc)
 
+
 if __name__ == "__main__":
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py34,py35
+envlist = py27,pypy,py34,py35,py36,py37
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37
+#envlist = py27,pypy,py34,py35,py36,py37
+envlist = py37
 
 [testenv]
 setenv =


### PR DESCRIPTION
This update makes us use py36 and py37 as well as use tc-github v1 instead of v0

along with it we switch to python official docker images rather than using the test-runner which we need to try and build python ourselves.

The repo was currently failing tests due to flake8 dying.