### PR TITLE
Lazily format all log messages

### DIFF
--- a/redo/__init__.py
+++ b/redo/__init__.py
@@ -143,16 +143,16 @@ def retry(action, attempts=5, sleeptime=60, max_sleeptime=5 * 60,
 
     action_name = getattr(action, '__name__', action)
     if log_args and (args or kwargs):
-        log_attempt_format = ("retry: calling %s with args: %s,"
-                              " kwargs: %s, attempt #%%d"
-                              % (action_name, args, kwargs))
+        log_attempt_args = ("retry: calling %s with args: %s,"
+                            " kwargs: %s, attempt #%d",
+                            action_name, args, kwargs)
     else:
-        log_attempt_format = ("retry: calling %s, attempt #%%d"
-                              % action_name)
+        log_attempt_args = ("retry: calling %s, attempt #%d",
+                            action_name)
 
     if max_sleeptime < sleeptime:
-        log.debug("max_sleeptime %d less than sleeptime %d" % (
-            max_sleeptime, sleeptime))
+        log.debug("max_sleeptime %d less than sleeptime %d",
+                  max_sleeptime, sleeptime)
 
     n = 1
     for _ in retrier(attempts=attempts, sleeptime=sleeptime,
@@ -160,14 +160,15 @@ def retry(action, attempts=5, sleeptime=60, max_sleeptime=5 * 60,
                      jitter=jitter):
         try:
             logfn = log.info if n != 1 else log.debug
-            logfn(log_attempt_format, n)
+            log_attempt_args += (n, )
+            logfn(*log_attempt_args)
             return action(*args, **kwargs)
         except retry_exceptions:
             log.debug("retry: Caught exception: ", exc_info=True)
             if cleanup:
                 cleanup()
             if n == attempts:
-                log.info("retry: Giving up on %s" % action_name)
+                log.info("retry: Giving up on %s", action_name)
                 raise
             continue
         finally:


### PR DESCRIPTION
## What's in this PR

This will prevent spending too much time string-formatting log statements that
will never end up being handled (as is often the case for `DEBUG`).

Since `args` and `kwargs` can be arbitrary large (and have big string
representations), this can become quite a big performance improvement.

Note that you already use this scheme here for example: https://github.com/mozilla-releng/redo/blob/3b1a735e6acfb5efdd1fe53ae8b61ac635020a5a/redo/__init__.py#L66

## Why this matters

Your lib is used by [Catalyst](https://github.com/enigmampc/catalyst), the algo trading library.

`retry` happens to wrap one of the most frequently ran functions to get exchange data, and while profiling it, I realized the full backtest code spent around 10% in `retry`, which shouldn't really have that kind of overhead. (this might be due to args/kwargs having pretty complex objects).

Some visuals, if you like flame graphs:

### Before

![before](https://user-images.githubusercontent.com/4542383/46511044-4bba3700-c81a-11e8-8863-5780ec8496ca.png)

Notice this big space at the left of each blue rectangle? This is a lot of overhead!

### After

![after](https://user-images.githubusercontent.com/4542383/46511046-4d83fa80-c81a-11e8-8b23-947636a140f7.png)

With a manually patched library, the overhead is pretty much gone!

## References

From the [`logging` library's docs](https://docs.python.org/3/library/logging.html#logging.debug):

> The `msg` is the message format string, and the `args` are the arguments which are merged into `msg` using the string formatting operator.

There is also a [pylint warning](http://pylint-messages.wikidot.com/messages:w1201) specifically for that anti-pattern.
