### PR TITLE
use shared releng project workers

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -24,7 +24,7 @@ tasks:
            ['py37-black', 'python:3.7']]
     each(py):
       taskId: "${as_slugid(py[0])}"
-      provisionerId: "proj-redo"
+      provisionerId: "proj-releng"
       workerType: "ci"
       created: {$eval: 'now'}
       deadline: {$fromNow: '1 hour'}


### PR DESCRIPTION
There are other releng projects, so it makes sense to make a consolidated project rather than one specific to redo.

PR here: https://github.com/mozilla/community-tc-config/pull/52

I've applied a temporary config that should will allow redo to use this worker-pool, once this is landed here I'll merge and apply the PR above.

Also, it looks like the tc.net github integration is still required for merges to this repo.