### PR TITLE
Inherit argv from sys when being called

### DIFF
--- a/src/redo/cmd.py
+++ b/src/redo/cmd.py
@@ -12,8 +12,11 @@ from redo import retrying
 log = logging.getLogger(__name__)
 
 
-def main(argv):
+def main(argv=None):
     from argparse import ArgumentParser, REMAINDER
+
+    if argv is None:
+        argv = sys.argv
 
     parser = ArgumentParser()
     parser.add_argument("-a", "--attempts", type=int, default=5, help="How many times to retry.")
@@ -53,4 +56,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main()


### PR DESCRIPTION
to avoid the entry script from throwing an error when being called:

```
[nix-shell:/home/jon/.cache/nixpkgs-review/pr-79273]$ ./results/python37Packages.redo/bin/retry --help
Traceback (most recent call last):
  File "/nix/store/6sb9lp6jqv9pmmb5c23n1z6vg11prhai-python3.7-redo-2.0.3/bin/.retry-wrapped", line 9, in <module>
    sys.exit(main())
TypeError: main() missing 1 required positional argument: 'argv'
```