### PR TITLE
fix: Add 2.0.4 history

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,18 @@
 #####
+2.0.4
+#####
+
+* Add Mozilla code of conduct
+* Improve formatting with black
+* Update taskcluster.yml
+* Improve testing with tox
+* Update MANIFEST file
+* Add .dirschema.yml file
+* Fix rst headings
+* Add LICENSE file
+* Fix linting failures
+
+#####
 2.0.3
 #####
 


### PR DESCRIPTION
We also need to tag the commit that was used for 2.0.4 - judging by the date it looks like it should be 748a8470be7520a83bf964d0ccf8e7301fe157fd

Closes #76 